### PR TITLE
fix: change renovate to not have immortal PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "default:base"
   ],
-  "schedule": "every weekend"
+  "schedule": "every other friday"
 }


### PR DESCRIPTION
We also want to pull back on the update frequency as it isn't necessary.