### PR TITLE
feat: switch to discord command text choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # AEC Collective
-This is th source code for the [AEC Collective](https://www.aeccollective.com).
 
-The AEC Collective is a community for the Architecture, Engineering, and Construction. It is uses the Discord program which is a free voice, video and text chat app that you can access via PC, browser, or mobile phone. We look to help mentor those just starting in the industry, and provide a great place for networking with your peers around the world. We can all benefit from understanding each related niche better, but also understanding our own niche outside of our geographic region.
+This is the source code for the [AEC Collective](https://www.aeccollective.com).
+
+The AEC Collective is a community for the Architecture, Engineering, and Construction. It is uses the Discord program which is a free voice, video and text chat app that you can access via PC, browser, or mobile phone. We look to help mentor those starting in the industry, and provide a great place for networking with your peers around the world. We can all benefit from understanding each related niche better, but also understanding our own niche outside of our geographic region.
 
 Please visit the website to join the community.
 

--- a/commands/functions/discord-commands.js
+++ b/commands/functions/discord-commands.js
@@ -58,74 +58,129 @@ exports.handler = async function (event, context) {
 
   // list of allowed roles
   const allowedRoles = new Map([
-    ['420948305464262659', 'Professional'],
-    ['625449975869997089', 'Business Admin'],
-    ['625450309556371467', 'BIM Specialist'],
-    ['420948044909903872', 'Student'],
-    ['421691951302049812', 'Interested'],
-    ['420954780609937429', 'Architecture'],
-    ['420954942375854080', 'Engineering'],
-    ['625451030116565005', 'Structural'],
-    ['625450766483849248', 'Electrical'],
-    ['625450815150358539', 'Mechanical'],
-    ['420954975083036682', 'Construction']
+    ['Student', '420948044909903872'],
+    ['Professional', '420948305464262659'],
+    ['Business Administration', '625449975869997089'],
+    ['BIM Specialist', '625450309556371467'],
+    ['Interested', '421691951302049812'],
+    ['Architecture', '420954780609937429'],
+    ['Engineering', '420954942375854080'],
+    ['Structural', '625451030116565005'],
+    ['Electrical', '625450766483849248'],
+    ['Mechanical', '625450815150358539'],
+    ['Construction', '420954975083036682']
   ]);
 
-  const requestedRole = body.data.options[0].value;
-  const userID = body.member.user.id;
+  if (body.data.name === 'role' || body.data.name === 'field') {
+    const requestedRole = body.data.options[0].value;
+    const userID = body.member.user.id;
 
-  if (allowedRoles.get(requestedRole)) {
-    try {
-      const roleURL = `${discord_api}/guilds/${GUILD_ID}/members/${userID}/roles/${requestedRole}`;
-      const response = await fetch(roleURL, {
-        method: 'put',
-        headers
-      });
-    } catch (e) {
-      console.error(e);
+    if (allowedRoles.get(requestedRole)) {
+      try {
+        const roleURL = `${discord_api}/guilds/${GUILD_ID}/members/${userID}/roles/${allowedRoles.get(
+          requestedRole
+        )}`;
+        const response = await fetch(roleURL, {
+          method: 'put',
+          headers
+        });
+      } catch (e) {
+        console.error(e);
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            type: 4,
+            data: {
+              tts: false,
+              content: `Error setting permissions.`,
+              embeds: [],
+              allowed_mentions: []
+            }
+          })
+        };
+      }
+
       return {
         statusCode: 200,
         body: JSON.stringify({
           type: 4,
           data: {
             tts: false,
-            content: `Error setting permissions.`,
+            content: `${requestedRole} has been added to <@${body.member.user.id}>.`,
             embeds: [],
-            allowed_mentions: []
+            allowed_mentions: { parse: ['users'] }
+          }
+        })
+      };
+    } else {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          type: 4,
+          data: {
+            tts: false,
+            content: `Sorry, <@${body.member.user.id}>, ${requestedRole} is not an allowed option to self assign.`,
+            embeds: [],
+            allowed_mentions: { parse: ['users'] }
           }
         })
       };
     }
+  } else if (body.data.name === 'remove') {
+    const roleToRemove = body.data.options[0].options[0].value;
+    const userID = body.member.user.id;
 
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        type: 4,
-        data: {
-          tts: false,
-          content: `The ${allowedRoles.get(
-            requestedRole
-          )} role has been added for you.`,
-          embeds: [],
-          allowed_mentions: []
-        }
-      })
-    };
-  } else {
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        type: 4,
-        data: {
-          tts: false,
-          content: `The ${allowedRoles.get(
-            requestedRole
-          )} role is not an allowed option to self assign.`,
-          embeds: [],
-          allowed_mentions: []
-        }
-      })
-    };
+    if (allowedRoles.get(roleToRemove)) {
+      try {
+        const roleURL = `${discord_api}/guilds/${GUILD_ID}/members/${userID}/roles/${allowedRoles.get(
+          roleToRemove
+        )}`;
+        const response = await fetch(roleURL, {
+          method: 'delete',
+          headers
+        });
+      } catch (e) {
+        console.error(e);
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            type: 4,
+            data: {
+              tts: false,
+              content: `Error removing permissions.`,
+              embeds: [],
+              allowed_mentions: []
+            }
+          })
+        };
+      }
+
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          type: 4,
+          data: {
+            tts: false,
+            content: `${roleToRemove} has been removed from <@${body.member.user.id}>.`,
+            embeds: [],
+            allowed_mentions: { parse: ['users'] }
+          }
+        })
+      };
+    } else {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          type: 4,
+          data: {
+            tts: false,
+            content: `Sorry, <@${body.member.user.id}>, ${roleToRemove} cannot be removed.`,
+            embeds: [],
+            allowed_mentions: { parse: ['users'] }
+          }
+        })
+      };
+    }
   }
 
   return {
@@ -134,7 +189,7 @@ exports.handler = async function (event, context) {
       type: 4,
       data: {
         tts: false,
-        content: 'I am not certain what else to say...',
+        content: 'I am not certain what to do with this...',
         embeds: [],
         allowed_mentions: []
       }

--- a/commands/functions/discord-commands.js
+++ b/commands/functions/discord-commands.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch');
-const interactions = require('discord-interactions');
+const { verifyKey } = require('discord-interactions');
 
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
 
@@ -12,37 +12,44 @@ const headers = {
 };
 
 exports.handler = async function (event, context) {
-  const body = JSON.parse(event.body);
-  try {
-    const signature = event.headers['x-signature-ed25519'];
-    const timestamp = event.headers['x-signature-timestamp'];
-    const isValidRequest = interactions.verifyKey(
-      event.body,
-      signature,
-      timestamp,
-      BOT_PUBLIC_KEY
-    );
-    if (!isValidRequest) {
-      return {
-        statusCode: 401,
-        body: JSON.stringify({ message: 'Bad request signature' })
-      };
-    }
-  } catch (e) {
+  if (!DISCORD_BOT_TOKEN) {
+    console.error(`DISCORD_BOT_TOKEN is not defined.`);
+  }
+  if (!BOT_PUBLIC_KEY) {
+    console.error(`BOT_PUBLIC_KEY is not defined.`);
+  }
+
+  if (event.httpMethod !== 'POST') {
     return {
       statusCode: 401,
-      body: JSON.stringify({ message: 'Bad request signature' })
+      body: JSON.stringify({
+        type: 2,
+        content: 'bad post'
+      })
     };
+  }
+
+  const body = JSON.parse(event.body);
+  const signature = event.headers['x-signature-ed25519'];
+  const timestamp = event.headers['x-signature-timestamp'];
+  const isValidRequest = verifyKey(
+    event.body,
+    signature,
+    timestamp,
+    BOT_PUBLIC_KEY
+  );
+
+  if (!isValidRequest) {
+    return jsonify({
+      code: 401,
+      type: 2,
+      data: { content: 'Bad request signature' }
+    });
   }
 
   // return the ping (discord checking if service is active)
   if (body.type === 1) {
-    return {
-      statusCode: 200,
-      body: JSON.stringify({
-        type: 1
-      })
-    };
+    return jsonify({ code: 200, type: 1, data: {} });
   }
 
   // for reference
@@ -71,7 +78,10 @@ exports.handler = async function (event, context) {
     ['Construction', '420954975083036682']
   ]);
 
-  if (body.data.name === 'role' || body.data.name === 'field') {
+  if (
+    body.type === 2 &&
+    (body.data.name === 'role' || body.data.name === 'field')
+  ) {
     const requestedRole = body.data.options[0].value;
     const userID = body.member.user.id;
 
@@ -86,45 +96,39 @@ exports.handler = async function (event, context) {
         });
       } catch (e) {
         console.error(e);
-        return {
-          statusCode: 200,
-          body: JSON.stringify({
-            type: 4,
-            data: {
-              tts: false,
-              content: `Error setting permissions.`,
-              embeds: [],
-              allowed_mentions: []
-            }
-          })
-        };
+        return jsonify({
+          code: 200,
+          type: 4,
+          data: {
+            tts: false,
+            content: `Error setting permissions.`,
+            embeds: [],
+            allowed_mentions: []
+          }
+        });
       }
 
-      return {
-        statusCode: 200,
-        body: JSON.stringify({
-          type: 4,
-          data: {
-            tts: false,
-            content: `${requestedRole} has been added to <@${body.member.user.id}>.`,
-            embeds: [],
-            allowed_mentions: { parse: ['users'] }
-          }
-        })
-      };
+      return jsonify({
+        code: 200,
+        type: 4,
+        data: {
+          tts: false,
+          content: `${requestedRole} has been added to <@${body.member.user.id}>.`,
+          embeds: [],
+          allowed_mentions: { parse: ['users'] }
+        }
+      });
     } else {
-      return {
-        statusCode: 200,
-        body: JSON.stringify({
-          type: 4,
-          data: {
-            tts: false,
-            content: `Sorry, <@${body.member.user.id}>, ${requestedRole} is not an allowed option to self assign.`,
-            embeds: [],
-            allowed_mentions: { parse: ['users'] }
-          }
-        })
-      };
+      return jsonify({
+        code: 200,
+        type: 4,
+        data: {
+          tts: false,
+          content: `Sorry, <@${body.member.user.id}>, ${requestedRole} is not an allowed option to self assign.`,
+          embeds: [],
+          allowed_mentions: { parse: ['users'] }
+        }
+      });
     }
   } else if (body.data.name === 'remove') {
     const roleToRemove = body.data.options[0].options[0].value;
@@ -141,58 +145,64 @@ exports.handler = async function (event, context) {
         });
       } catch (e) {
         console.error(e);
-        return {
-          statusCode: 200,
-          body: JSON.stringify({
-            type: 4,
-            data: {
-              tts: false,
-              content: `Error removing permissions.`,
-              embeds: [],
-              allowed_mentions: []
-            }
-          })
-        };
+        return jsonify({
+          code: 200,
+          type: 4,
+          data: {
+            tts: false,
+            content: `Error removing permissions.`,
+            embeds: [],
+            allowed_mentions: []
+          }
+        });
       }
 
-      return {
-        statusCode: 200,
-        body: JSON.stringify({
-          type: 4,
-          data: {
-            tts: false,
-            content: `${roleToRemove} has been removed from <@${body.member.user.id}>.`,
-            embeds: [],
-            allowed_mentions: { parse: ['users'] }
-          }
-        })
-      };
+      return jsonify({
+        code: 200,
+        type: 4,
+        data: {
+          tts: false,
+          content: `${roleToRemove} has been removed from <@${body.member.user.id}>.`,
+          embeds: [],
+          allowed_mentions: { parse: ['users'] }
+        }
+      });
     } else {
-      return {
-        statusCode: 200,
-        body: JSON.stringify({
-          type: 4,
-          data: {
-            tts: false,
-            content: `Sorry, <@${body.member.user.id}>, ${roleToRemove} cannot be removed.`,
-            embeds: [],
-            allowed_mentions: { parse: ['users'] }
-          }
-        })
-      };
+      return jsonify({
+        code: 200,
+        type: 4,
+        data: {
+          tts: false,
+          content: `Sorry, <@${body.member.user.id}>, ${roleToRemove} cannot be removed.`,
+          embeds: [],
+          allowed_mentions: { parse: ['users'] }
+        }
+      });
     }
   }
 
+  return jsonify({
+    code: 200,
+    type: 4,
+    data: {
+      tts: false,
+      content: 'I am not certain what to do with this...',
+      embeds: [],
+      allowed_mentions: []
+    }
+  });
+};
+
+const jsonify = ({ type, code, data }) => {
+  console.log({ type, code, data });
   return {
-    statusCode: 200,
+    statusCode: code,
+    headers: {
+      'Content-Type': 'application/json'
+    },
     body: JSON.stringify({
-      type: 4,
-      data: {
-        tts: false,
-        content: 'I am not certain what to do with this...',
-        embeds: [],
-        allowed_mentions: []
-      }
+      type: type,
+      data
     })
   };
 };

--- a/commands/init-command.js
+++ b/commands/init-command.js
@@ -9,35 +9,182 @@ const run = async () => {
 
   const url = `${discord_api}/applications/${APPLICATION_ID}/guilds/${GUILD_ID}/commands`;
 
-  const bodyContent = {
-    name: 'role',
-    description:
-      'Ask the the bot to assign me a role. You may run this again to add another.',
-    options: [
-      {
-        name: 'role-to-set-me-as',
-        description: 'Choose your role. You may run this again to add another.',
-        type: 8, // 8 is type ROLE
-        required: true
-      }
-    ]
-  };
+  const contents = [
+    {
+      name: 'role',
+      description:
+        'Ask the the bot to assign me a role. You may run this again to add another.',
+      options: [
+        {
+          name: 'role-to-set-me-as',
+          description:
+            'Choose your role. You may run this again to add another.',
+          type: 3, // 3 is string
+          required: true,
+          choices: [
+            {
+              name: 'Student',
+              value: 'Student'
+            },
+            {
+              name: 'Professional',
+              value: 'Professional'
+            },
+            {
+              name: 'Business Administration',
+              value: 'Business Administration'
+            },
+            {
+              name: 'BIM Specialist',
+              value: 'BIM Specialist'
+            },
+            {
+              name: 'Interested',
+              value: 'Interested'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'field',
+      description:
+        'Ask the bot to assign a field the represents your background. You may run this again to add another.',
+      options: [
+        {
+          name: 'field-to-set-me-as',
+          description:
+            'Choose your role. You may run this again to add another.',
+          type: 3, // 3 is string
+          required: true,
+          choices: [
+            {
+              name: 'Architecture',
+              value: 'Architecture'
+            },
+            {
+              name: 'Engineering',
+              value: 'Engineering'
+            },
+            {
+              name: 'Structural',
+              value: 'Structural'
+            },
+            {
+              name: 'Electrical',
+              value: 'Electrical'
+            },
+            {
+              name: 'Mechanical',
+              value: 'Mechanical'
+            },
+            {
+              name: 'Construction',
+              value: 'Construction'
+            }
+          ]
+        }
+      ]
+    },
+    {
+      name: 'remove',
+      description: 'Remove a role or a field.',
+      options: [
+        {
+          name: 'role',
+          description: 'Ask the bot to remove a previously requested role.',
+          type: 1, // 1 is type SUB_COMMAND
+          options: [
+            {
+              name: 'role-to-set-me-as',
+              description: 'Remove a role that you previously requested.',
+              type: 3, // 3 is string
+              required: true,
+              choices: [
+                {
+                  name: 'Student',
+                  value: 'Student'
+                },
+                {
+                  name: 'Professional',
+                  value: 'Professional'
+                },
+                {
+                  name: 'Business Administration',
+                  value: 'Business Administration'
+                },
+                {
+                  name: 'BIM Specialist',
+                  value: 'BIM Specialist'
+                },
+                {
+                  name: 'Interested',
+                  value: 'Interested'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          name: 'field',
+          description: 'Ask the bot to remove a previously requested field.',
+          type: 1, // 1 is type SUB_COMMAND
+          options: [
+            {
+              name: 'role-to-set-me-as',
+              description: 'Remove a field that you previously assigned.',
+              type: 3, // 3 is string
+              required: true,
+              choices: [
+                {
+                  name: 'Architecture',
+                  value: 'Architecture'
+                },
+                {
+                  name: 'Engineering',
+                  value: 'Engineering'
+                },
+                {
+                  name: 'Structural',
+                  value: 'Structural'
+                },
+                {
+                  name: 'Electrical',
+                  value: 'Electrical'
+                },
+                {
+                  name: 'Mechanical',
+                  value: 'Mechanical'
+                },
+                {
+                  name: 'Construction',
+                  value: 'Construction'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ];
 
   const headers = {
     'Content-Type': 'application/json',
     Authorization: `Bot ${DISCORD_BOT_TOKEN}`
   };
 
-  const json = JSON.stringify(bodyContent);
+  for (let bodyContent of contents) {
+    const json = JSON.stringify(bodyContent);
 
-  const response = await fetch(url, {
-    method: 'post',
-    body: json,
-    headers
-  });
-  const data = await response.json();
+    const response = await fetch(url, {
+      method: 'post',
+      body: json,
+      headers
+    });
+    const data = await response.json();
 
-  console.dir(data);
+    console.dir(data);
+  }
 };
 
 run();

--- a/package.json
+++ b/package.json
@@ -51,8 +51,12 @@
     "theme-ui": "0.3.5"
   },
   "devDependencies": {
-    "discord-interactions": "^1.3.3",
+    "discord-interactions": "^2.3.0",
     "node-fetch": "^2.6.1",
-    "prettier": "2.2.1"
+    "prettier": "2.3.2"
+  },
+  "volta": {
+    "node": "14.17.4",
+    "yarn": "1.22.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,10 +5459,10 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-interactions@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/discord-interactions/-/discord-interactions-1.3.3.tgz#3c0d95b775a19a796fbaa56cbb9e2e3b89b0a848"
-  integrity sha512-iW50e+pteFEbBFswubZhmDQd9wC1Xh1tqcjbeYY8GLYj4A7A4rS6kDZzN33Y10iSJcuSBWogsW65rQuoKGWhlA==
+discord-interactions@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/discord-interactions/-/discord-interactions-2.3.0.tgz#f83a025056250a19876274a983277b884bb3d51b"
+  integrity sha512-PboDGXOUYVKfVvFo5nMr1FbGJGeYOvC3ZB1UllQmLHLoifc5kmY7PHM5hm6QeYOkdoot+/eKcwXxfki3Mh+IHg==
   dependencies:
     tweetnacl "^1.0.3"
 
@@ -12082,10 +12082,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
+  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
 
 prettier@^2.0.5:
   version "2.1.2"


### PR DESCRIPTION
Switch from the discord command relying on the roles object to string choices. This required splitting it up into two commands, `/role` and `/field`.